### PR TITLE
Fixes script so it works with latest version of AAXtoMP3

### DIFF
--- a/aax2mp3_easy.sh
+++ b/aax2mp3_easy.sh
@@ -63,4 +63,4 @@ ACTIVATION=$(python audible-activator-feature_login_as_arg/audible-activator.py 
 #--------------------------
 # Converting files
 #--------------------------
-bash AAXtoMP3-master/AAXtoMP3 $ACTIVATION $FILES
+bash AAXtoMP3-master/AAXtoMP3 -A $ACTIVATION $FILES


### PR DESCRIPTION
Latest version of AAXtoMP3 requires -A as a parameter to script. 

Closes #10 